### PR TITLE
Adds constructor to typings file

### DIFF
--- a/dynamicsnode.d.ts
+++ b/dynamicsnode.d.ts
@@ -113,6 +113,7 @@ declare module 'dynamicsnode' {
      * @param {string} connectionString Optional. A valid connection string or connection string name
      */
     export class CRMClient {
+        constructor(connectionString?: string, version?: string);
         whoAmI(): WhoAmIResponse;
         testConnection(): void;
         retrieve(entityName: string, idOrConditions: string | Guid | Object, pColumns?: string | string[] | boolean): any;


### PR DESCRIPTION
Somewhere along the line the constructor for `CRMClient` was removed from the typings file, which was causing an error when I tried to use the library.

Instead of re-generating the typings I added this manually as I'm still learning quite a bit about typescript. I assume there's a way to automatically re-create the typings file, which is probably the right move here instead.